### PR TITLE
Permit all type of data to be checked if empty

### DIFF
--- a/src/Neoxia/Routing/ResponseFactory.php
+++ b/src/Neoxia/Routing/ResponseFactory.php
@@ -30,14 +30,14 @@ class ResponseFactory extends BaseResponseFactory
     }
 
     /**
-     * Check if an array, a string or a Collection is empty
+     * Check if the data set is empty
      *
-     * @param  \Illuminate\Support\Collection|array|string  $data
+     * @param  mixed  $data
      * @return bool
      */
     protected function dataIsEmpty($data)
     {
-        if ($data instanceof Collection) {
+        if (method_exists($data, 'isEmpty')) {
             return $data->isEmpty();
         } else {
             return empty($data);


### PR DESCRIPTION
For example, our `LengthAwarePaginator` (`paginate()` method) are throwing an error if they are empty.

You could also check if `$data` is an instance of `Arrayable` at the start, and convert it in array to avoid all theses problems and work with arrays in all the methods: 

```
        if ($data instanceof Arrayable) {
            $data = $data->toArray();
        }

        if ($this->dataIsEmpty($data)) {
            return $this->make('No Content', 204);
        }
...

    protected function dataIsEmpty($data)
    {
        return empty($data);
    }
```
