### PR TITLE
Add option: includeHeader (default: true)

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,5 +131,6 @@ The default options are the following.
     'encoding' => 'WINDOWS-1252',
     'delimiter' => ';',
     'quoted' => true,
+    'includeHeader' => true,
 ]
 ```

--- a/src/Neoxia/Routing/ResponseFactory.php
+++ b/src/Neoxia/Routing/ResponseFactory.php
@@ -43,6 +43,7 @@ class ResponseFactory extends BaseResponseFactory
             'encoding' => 'WINDOWS-1252',
             'delimiter' => ';',
             'quoted' => true,
+            'includeHeader' => true,
         ];
 
         return array_merge($baseOptions, $customOptions);
@@ -77,7 +78,10 @@ class ResponseFactory extends BaseResponseFactory
         } else {
             $csvArray = [];
 
-            $this->addHeaderToCsvArray($csvArray, $data, $options);
+            if ( $options['includeHeader']) {
+                $this->addHeaderToCsvArray($csvArray, $data, $options);
+            }
+
             $this->addRowsToCsvArray($csvArray, $data, $options);
 
             $csv = implode("\r\n", $csvArray);

--- a/tests/ResponseFactoryTest.php
+++ b/tests/ResponseFactoryTest.php
@@ -162,6 +162,15 @@ class ResponseFactoryTest extends PHPUnit_Framework_TestCase
         $this->assertCsvResponseIsValidAndEquals($response, "first_name;last_name\r\nJohn;Doe");
     }
 
+    public function testCsvCanFormatWithoutHeader()
+    {
+        $data = [['first_name' => 'John', 'last_name' => 'Doe']];
+
+        $response = $this->responseFactory->csv($data, 200, [], ['includeHeader' => false]);
+
+        $this->assertCsvResponseIsValidAndEquals($response, "\"John\";\"Doe\"");
+    }
+
     public function testCsvEscapeQuotes()
     {
         $data = [['My comment : "This is great !"']];


### PR DESCRIPTION
I needed an option to exclude the headers from the exported CSV and this did the trick. Default behavior is to leave them in (as before). Again, tests are passing and I have tried it out (successfully!) in a 5.5.13 project. Thanks!