### PR TITLE
Added support for Laravel 5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "description": "Add a CSV response type to Laravel",
     "require": {
         "php": ">=5.5.9",
-        "illuminate/routing": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*",
-        "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*"
+        "illuminate/routing": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*",
+        "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*|5.5.*|5.6.*|5.7.*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.8.*",


### PR DESCRIPTION
Allow the use of 5.7 version of the framework packages. The tests pass also with the newest version just fine.